### PR TITLE
fix: 認証システムのログイン・アカウント作成問題を修正

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -104,6 +104,19 @@ export const authApi = {
       throw error;
     }
   },
+
+  async register(username: string, email: string, password: string): Promise<any> {
+    try {
+      const response = await apiClient.post('/api/auth/register', {
+        username,
+        email,
+        password,
+      });
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  },
 };
 
 // ダッシュボードAPI

--- a/start_backend.py
+++ b/start_backend.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Advanced Crypto Trading Bot - Backend Server Startup
+"""
+import os
+import sys
+
+# プロジェクトルートをPythonパスに追加
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+if __name__ == "__main__":
+    import uvicorn
+    from backend.core.local_database import init_local_db
+    
+    print("🚀 Starting Advanced Crypto Trading Bot Backend...")
+    
+    # データベース初期化
+    print("📊 Initializing database...")
+    try:
+        init_local_db()
+        print("✅ Database initialized successfully")
+    except Exception as e:
+        print(f"❌ Database initialization failed: {e}")
+        sys.exit(1)
+    
+    # バックエンドサーバー起動
+    print("🔄 Starting FastAPI server...")
+    uvicorn.run(
+        "backend.main:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        log_level="info"
+    )


### PR DESCRIPTION
## 概要
ログインページでdemo/demoでのログインとアカウント作成ができない問題を修正しました。

## 問題
- データベース（DuckDB）が初期化されていない
- デモユーザー（demo/demo）が作成されていない  
- フロントエンドAPIクライアントにregisterメソッドが不足
- 環境設定ファイルがデフォルト値のまま

## 修正内容

### 1. データベース環境の構築
- ✅ `data/` と `logs/` ディレクトリを作成
- ✅ DuckDBデータベースを初期化
- ✅ デモユーザー（demo/demo）を作成済み

### 2. フロントエンドAPI修正
- ✅ `authApi` に `register` メソッドを追加
- ✅ RegisterForm からのAPI呼び出しに対応

### 3. 環境設定の修正
- ✅ `JWT_SECRET_KEY` を開発用に設定
- ✅ `NEXT_PUBLIC_API_URL` を `localhost:8000` に設定
- ✅ `NODE_ENV` を開発モードに変更

### 4. バックエンド起動スクリプトの追加
- ✅ `start_backend.py` でワンコマンド起動
- ✅ データベース初期化を自動実行

## テスト方法

### バックエンド起動
```bash
python start_backend.py
```

### フロントエンド起動
```bash
cd frontend && npm run dev
```

### ログインテスト
1. http://localhost:3000/login にアクセス
2. ユーザー名: `demo`, パスワード: `demo` でログイン

### アカウント作成テスト
1. http://localhost:3000/register にアクセス
2. 新規ユーザー情報を入力して登録

## 技術詳細
- **データベース**: DuckDB (`data/crypto_bot.db`)
- **認証**: JWT + httpOnlyクッキー
- **フロントエンド**: Next.js + TypeScript
- **バックエンド**: FastAPI + Pydantic

## マージ後の動作確認
- [ ] demo/demo でログインできる
- [ ] 新規アカウント作成ができる
- [ ] バックエンドサーバーが正常に起動する

🤖 Generated with [Claude Code](https://claude.ai/code)