### PR TITLE
🚨 Hotfix: Vercel環境での認証問題を緊急修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ cp .env.example .env
 # .envファイルを編集してSupabase情報を設定
 
 # 3. バックエンド起動
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
-uvicorn backend.main:app --reload
+
+## ローカル開発（フル機能）
+python start_backend.py
+
+## または軽量認証テスト
+python test_auth_simple.py  # ポート8001で起動
 
 # 4. フロントエンド起動（新しいターミナル）
 cd frontend && npm install && npm run dev

--- a/api/auth_simple.py
+++ b/api/auth_simple.py
@@ -1,0 +1,218 @@
+"""
+Vercel Serverless Function - Simple Authentication API
+DuckDBに依存しない軽量認証システム
+"""
+
+import os
+import hashlib
+import hmac
+import json
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+from fastapi import FastAPI, HTTPException, Request, Response, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPBearer
+from pydantic import BaseModel
+import jwt
+
+# 環境変数から設定を取得
+JWT_SECRET = os.getenv("JWT_SECRET_KEY", "dev-jwt-secret-key-for-advanced-crypto-trading-bot-development-32-chars")
+JWT_ALGORITHM = "HS256"
+JWT_EXPIRATION = int(os.getenv("JWT_EXPIRATION", "86400"))  # 24時間
+
+app = FastAPI(title="Crypto Bot Simple Auth API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+security = HTTPBearer()
+
+# リクエスト/レスポンスモデル
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+class RegisterRequest(BaseModel):
+    username: str
+    email: str
+    password: str
+
+class AuthResponse(BaseModel):
+    success: bool
+    message: str
+    user: Optional[Dict] = None
+
+# メモリベースの簡易ユーザーストレージ（実際にはRedisやSupabaseを使用）
+# デモ用のハードコードされたユーザー
+DEMO_USERS = {
+    "demo": {
+        "id": "demo-user-id",
+        "username": "demo",
+        "email": "demo@example.com",
+        "password_hash": hashlib.pbkdf2_hmac('sha256', 'demo'.encode(), b'salt', 100000).hex(),
+        "role": "viewer",
+        "created_at": datetime.now().isoformat()
+    }
+}
+
+# 動的ユーザー登録用ストレージ（実際の実装ではデータベースを使用）
+REGISTERED_USERS = {}
+
+def hash_password(password: str) -> str:
+    """パスワードをハッシュ化"""
+    return hashlib.pbkdf2_hmac('sha256', password.encode(), b'salt', 100000).hex()
+
+def verify_password(password: str, hashed: str) -> bool:
+    """パスワードを検証"""
+    return hash_password(password) == hashed
+
+def get_user(username: str) -> Optional[Dict]:
+    """ユーザーを取得"""
+    if username in DEMO_USERS:
+        return DEMO_USERS[username]
+    if username in REGISTERED_USERS:
+        return REGISTERED_USERS[username]
+    return None
+
+def create_access_token(user_data: Dict) -> str:
+    """JWTアクセストークンを作成"""
+    payload = {
+        "sub": user_data["username"],
+        "user_id": user_data["id"],
+        "role": user_data["role"],
+        "exp": datetime.utcnow() + timedelta(seconds=JWT_EXPIRATION),
+        "iat": datetime.utcnow()
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+@app.post("/login", response_model=AuthResponse)
+async def login(request: LoginRequest, response: Response):
+    """ログイン処理"""
+    try:
+        # ユーザー検証
+        user = get_user(request.username)
+        if not user or not verify_password(request.password, user["password_hash"]):
+            raise HTTPException(status_code=401, detail="Invalid username or password")
+        
+        # JWTトークン生成
+        access_token = create_access_token(user)
+        
+        # httpOnlyクッキーに設定
+        response.set_cookie(
+            key="access_token",
+            value=access_token,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=JWT_EXPIRATION
+        )
+        
+        return AuthResponse(
+            success=True,
+            message="Login successful",
+            user={
+                "id": user["id"],
+                "username": user["username"],
+                "email": user["email"],
+                "role": user["role"]
+            }
+        )
+    
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Login failed: {str(e)}")
+
+@app.post("/register", response_model=AuthResponse)
+async def register(request: RegisterRequest):
+    """ユーザー登録処理"""
+    try:
+        # 重複チェック
+        if get_user(request.username):
+            raise HTTPException(status_code=400, detail="Username already exists")
+        
+        # 新規ユーザー作成
+        user_id = str(uuid.uuid4())
+        new_user = {
+            "id": user_id,
+            "username": request.username,
+            "email": request.email,
+            "password_hash": hash_password(request.password),
+            "role": "viewer",
+            "created_at": datetime.now().isoformat()
+        }
+        
+        # メモリストレージに保存（本番では永続化データベースを使用）
+        REGISTERED_USERS[request.username] = new_user
+        
+        return AuthResponse(
+            success=True,
+            message="User registered successfully",
+            user={
+                "id": new_user["id"],
+                "username": new_user["username"],
+                "email": new_user["email"],
+                "role": new_user["role"]
+            }
+        )
+    
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Registration failed: {str(e)}")
+
+@app.post("/logout")
+async def logout(response: Response):
+    """ログアウト処理"""
+    response.delete_cookie(key="access_token")
+    return {"success": True, "message": "Logged out successfully"}
+
+@app.get("/me")
+async def get_current_user(request: Request):
+    """現在のユーザー情報を取得"""
+    try:
+        # クッキーからトークンを取得
+        token = request.cookies.get("access_token")
+        if not token:
+            raise HTTPException(status_code=401, detail="Not authenticated")
+        
+        # JWTトークンをデコード
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        username = payload.get("sub")
+        
+        user = get_user(username)
+        if not user:
+            raise HTTPException(status_code=401, detail="User not found")
+        
+        return {
+            "id": user["id"],
+            "username": user["username"],
+            "email": user["email"],
+            "role": user["role"]
+        }
+    
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/health")
+async def health_check():
+    """ヘルスチェック"""
+    return {
+        "status": "healthy",
+        "timestamp": datetime.now().isoformat(),
+        "version": "1.0.0"
+    }
+
+# Vercel handler
+handler = app

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,7 +21,9 @@ import {
 } from '@/lib/mockData';
 
 // API設定
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 
+  (typeof window !== 'undefined' && window.location.origin) || 
+  'http://localhost:8000';
 
 // Axiosインスタンス作成
 const apiClient = axios.create({

--- a/test_auth_simple.py
+++ b/test_auth_simple.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+Simple auth API のテスト用起動スクリプト
+"""
+import uvicorn
+
+if __name__ == "__main__":
+    print("🚀 Starting Simple Auth API Test Server...")
+    print("📡 Demo user: username=demo, password=demo")
+    print("🔗 Test URLs:")
+    print("   - POST http://localhost:8001/login")
+    print("   - POST http://localhost:8001/register")
+    print("   - GET  http://localhost:8001/health")
+    
+    uvicorn.run(
+        "api.auth_simple:app",
+        host="0.0.0.0",
+        port=8001,
+        reload=True,
+        log_level="info"
+    )

--- a/vercel.json
+++ b/vercel.json
@@ -22,7 +22,7 @@
   "rewrites": [
     {
       "source": "/api/auth/(.*)",
-      "destination": "/api/auth.py"
+      "destination": "/api/auth_simple.py"
     },
     {
       "source": "/api/portfolio/(.*)",
@@ -69,7 +69,10 @@
     "USE_REAL_DATA": "true",
     "RATE_LIMIT_ENABLED": "true",
     "MAX_REQUESTS_PER_MINUTE": "60",
-    "ENABLE_PRICE_STREAMING": "false"
+    "ENABLE_PRICE_STREAMING": "false",
+    "JWT_SECRET_KEY": "prod-jwt-secret-key-vercel-crypto-trading-bot-32-chars-long",
+    "JWT_ALGORITHM": "HS256",
+    "JWT_EXPIRATION": "86400"
   },
   "github": {
     "silent": false


### PR DESCRIPTION
## 🚨 緊急修正の背景
マージ後にサーバー上でdemo/demoログインができない問題が発生。Vercel環境でDuckDBが使用できないことが原因でした。

## 問題の詳細
- ❌ Vercelサーバーレス環境ではDuckDB使用不可
- ❌ デモユーザー（demo/demo）が作成されない
- ❌ API ルーティングの設定問題
- ❌ 環境変数の不足

## 🛠️ 修正内容

### 1. Vercel専用軽量認証API
**新規作成: `api/auth_simple.py`**
- ✅ DuckDBに依存しない独立した認証システム  
- ✅ メモリベースの簡易ユーザーストレージ
- ✅ JWT + httpOnlyクッキー認証
- ✅ デモユーザー（demo/demo）をハードコード
- ✅ 新規ユーザー登録機能

### 2. Vercel設定の修正
**更新: `vercel.json`**
- ✅ `/api/auth/*` を `auth_simple.py` にルーティング
- ✅ JWT_SECRET_KEY 等の環境変数追加
- ✅ 認証に必要な設定を完備

### 3. フロントエンド接続の改善
**更新: `frontend/src/lib/api.ts`**
- ✅ API_BASE_URL の動的設定
- ✅ 本番環境で現在のドメインを自動使用
- ✅ ローカル開発との互換性維持

### 4. 開発支援ツール
- ✅ `test_auth_simple.py` - 軽量認証テスト用
- ✅ `README.md` 更新 - 新しい起動方法を文書化

## 🎯 修正後の期待動作

### Vercel本番環境
- ✅ `demo` / `demo` でログイン可能
- ✅ 新規アカウント作成可能
- ✅ JWT認証が正常に動作
- ✅ セッション管理が適切に機能

### ローカル開発環境
- ✅ 従来通りの完全機能（`python start_backend.py`）
- ✅ 軽量テスト用（`python test_auth_simple.py`）

## 📋 テスト計画

### マージ前テスト
- [ ] CI/CDが通ること
- [ ] ローカルで軽量認証が動作すること

### マージ後テスト
- [ ] Vercel上でdemo/demoログインが成功すること
- [ ] 新規アカウント作成が動作すること
- [ ] JWT認証フローが完全に機能すること

## ⚠️ 重要な注意事項

### 制限事項
- メモリベースのため、サーバー再起動で登録ユーザー消失
- 同時ユーザー数に制限あり（Vercelのメモリ制限）

### 今後の改善計画
- Supabase等の永続化データベースへの移行
- Redis等を使用したセッション管理の改善

## 🚀 緊急性
この修正により、サーバー上での認証機能が即座に復旧します。本格的な改善は後続のPRで実施予定です。

🤖 Generated with [Claude Code](https://claude.ai/code)