### PR TITLE
feat: Phase A - 個人利用向け認証簡素化機能実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,9 @@ NTFY_SERVER=https://ntfy.sh
 
 # Redis設定（オプション）
 REDIS_PASSWORD=your-redis-password
+
+# 個人利用モード設定
+PERSONAL_MODE=false
+PERSONAL_MODE_AUTO_LOGIN=false
+PERSONAL_MODE_DEFAULT_USER=demo
+PERSONAL_MODE_SKIP_LIVE_TRADING_AUTH=false

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,83 @@
+# 🔧 トラブルシューティングガイド
+
+## 個人モード自動ログインが動作しない場合
+
+### 1. 環境変数の確認
+
+Vercel Dashboardで以下の環境変数が設定されているか確認：
+
+**必須の環境変数**:
+- `PERSONAL_MODE` = `true`
+- `PERSONAL_MODE_AUTO_LOGIN` = `true`
+- `NEXT_PUBLIC_PERSONAL_MODE` = `true`
+- `NEXT_PUBLIC_PERSONAL_MODE_AUTO_LOGIN` = `true`
+- `JWT_SECRET_KEY` = (32文字以上のランダム文字列)
+
+### 2. デプロイメントの再実行
+
+環境変数を設定/変更した後は、必ず再デプロイが必要です：
+
+**Vercel Dashboard から**:
+1. Deployments タブ
+2. 最新のデプロイメントの "..." メニュー
+3. "Redeploy" をクリック
+4. "Use existing Build Cache" のチェックを**外す**
+
+### 3. ブラウザキャッシュのクリア
+
+**Chrome/Edge**:
+- Ctrl+Shift+R (Windows) / Cmd+Shift+R (Mac)
+- または Developer Tools → Network → "Disable cache" にチェック
+
+### 4. APIエンドポイントの直接確認
+
+```bash
+# cURLで確認
+curl https://your-domain.vercel.app/api/auth/personal-mode-info
+
+# ブラウザで確認
+https://your-domain.vercel.app/api/auth/personal-mode-info
+```
+
+### 5. コンソールエラーの確認
+
+ブラウザのDeveloper Tools → Console でエラーを確認：
+- CORS エラー → 環境変数 `ALLOWED_ORIGINS` の確認
+- 401 Unauthorized → JWT_SECRET_KEY の設定確認
+- Network Error → APIエンドポイントの存在確認
+
+### 6. Vercel Function ログの確認
+
+Vercel Dashboard → Functions タブでエラーログを確認：
+- `api/auth_simple.py` のログを確認
+- エラーメッセージから原因を特定
+
+### 7. 環境変数のスコープ確認
+
+Vercel Dashboardで環境変数が正しいスコープに設定されているか確認：
+- Production ✓
+- Preview ✓
+- Development ✓
+
+### 8. .env ファイルの同期
+
+ローカル開発環境の場合：
+```bash
+vercel env pull .env.local
+```
+
+## それでも解決しない場合
+
+1. **GitHub Issue を作成**: 
+   https://github.com/shingo25/advanced-crypto-trading-bot/issues
+
+2. **以下の情報を提供**:
+   - エラーメッセージ（Console、Network）
+   - `/api/auth/health` の出力
+   - `/api/auth/personal-mode-info` の出力
+   - ブラウザとバージョン
+   - Vercel デプロイメントURL
+
+3. **一時的な回避策**:
+   - 通常のログイン（demo/demo）を使用
+   - 環境変数 `PERSONAL_MODE=false` に設定して通常モードで運用

--- a/VERCEL_ENV_SETUP.md
+++ b/VERCEL_ENV_SETUP.md
@@ -1,0 +1,128 @@
+# Vercel環境変数設定手順
+
+## 🎯 Phase A個人モード機能の本番環境設定
+
+### 必要な環境変数設定
+
+以下の環境変数をVercel Dashboardまたは CLI で設定してください：
+
+#### 1. バックエンド用環境変数
+```
+PERSONAL_MODE=true
+PERSONAL_MODE_AUTO_LOGIN=true
+PERSONAL_MODE_DEFAULT_USER=demo
+PERSONAL_MODE_SKIP_LIVE_TRADING_AUTH=false
+JWT_SECRET_KEY=your-secure-production-jwt-secret-32-chars
+ENVIRONMENT=production
+```
+
+#### 2. フロントエンド用環境変数（NEXT_PUBLIC_プレフィックス必須）
+```
+NEXT_PUBLIC_PERSONAL_MODE=true
+NEXT_PUBLIC_PERSONAL_MODE_AUTO_LOGIN=true
+```
+
+### 📱 Vercel Dashboard での設定方法
+
+1. **https://vercel.com/dashboard** にアクセス
+2. **advanced-crypto-trading-bot** プロジェクトを選択
+3. **Settings** タブ → **Environment Variables** をクリック
+4. 上記の環境変数を1つずつ追加
+   - **Environment**: Production, Preview, Development （すべて選択）
+
+### 💻 Vercel CLI での設定方法
+
+```bash
+# 1. プロジェクトディレクトリで実行
+cd /Users/arata/Dev/advanced-crypto-trading-bot
+
+# 2. 各環境変数を順次設定
+vercel env add PERSONAL_MODE
+# → "true" と入力
+# → すべての環境を選択
+
+vercel env add PERSONAL_MODE_AUTO_LOGIN
+# → "true" と入力
+
+vercel env add PERSONAL_MODE_DEFAULT_USER
+# → "demo" と入力
+
+vercel env add PERSONAL_MODE_SKIP_LIVE_TRADING_AUTH
+# → "false" と入力
+
+vercel env add JWT_SECRET_KEY
+# → "your-secure-production-jwt-secret-32-chars" と入力
+
+vercel env add ENVIRONMENT
+# → "production" と入力（Production環境のみ）
+
+vercel env add NEXT_PUBLIC_PERSONAL_MODE
+# → "true" と入力
+
+vercel env add NEXT_PUBLIC_PERSONAL_MODE_AUTO_LOGIN
+# → "true" と入力
+```
+
+### 🔄 再デプロイ実行
+
+環境変数設定後、再デプロイが必要です：
+
+```bash
+# PR #34 をマージしてmainブランチをデプロイ
+git checkout main
+git pull origin main
+git push origin main
+
+# または Vercel CLI で直接デプロイ
+vercel --prod
+```
+
+### ✅ 動作確認
+
+設定完了後、以下のURLで動作確認：
+
+1. **個人モード設定確認**:
+   ```
+   https://your-vercel-domain.vercel.app/api/auth/personal-mode-info
+   ```
+   
+   期待される結果:
+   ```json
+   {
+     "personal_mode": true,
+     "auto_login": true,
+     "default_user": "demo",
+     "skip_live_trading_auth": false,
+     "available_users": ["demo"]
+   }
+   ```
+
+2. **自動ログイン動作確認**:
+   ```
+   https://your-vercel-domain.vercel.app/
+   ```
+   
+   期待される動作:
+   - ログインページをスキップ
+   - ダッシュボードに直接遷移
+
+3. **API全体の動作確認**:
+   ```
+   https://your-vercel-domain.vercel.app/api/auth/health
+   ```
+
+### 🔒 セキュリティ注意事項
+
+- **JWT_SECRET_KEY**: 本番環境では必ず強力なランダム文字列（32文字以上）を使用
+- **個人モード**: 信頼できる環境でのみ有効化
+- **ENVIRONMENT=production**: 本番環境でのみ設定
+
+### 🐛 トラブルシューティング
+
+- 環境変数が反映されない → 再デプロイを実行
+- 自動ログインが動作しない → ブラウザのキャッシュをクリア
+- API エラー → `/api/auth/health` でヘルスチェック確認
+
+---
+
+**設定完了後、Vercel URLでの動作確認をお願いします！**

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import LoginForm from '@/components/auth/LoginForm';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { isAuthenticated, initialize } = useAuthStore();
+  const { isAuthenticated, initialize, personalModeInfo } = useAuthStore();
 
   useEffect(() => {
     initialize();
@@ -18,6 +18,19 @@ export default function LoginPage() {
       router.push('/dashboard');
     }
   }, [isAuthenticated, router]);
+
+  // 個人モードで自動ログイン有効な場合は、ログインページをスキップしてダッシュボードに進む
+  useEffect(() => {
+    if (personalModeInfo?.personal_mode && personalModeInfo?.auto_login && !isAuthenticated) {
+      // initializeで自動ログインが実行されるため、少し待ってからリダイレクト
+      const timer = setTimeout(() => {
+        if (!isAuthenticated) {
+          router.push('/dashboard');
+        }
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [personalModeInfo, isAuthenticated, router]);
 
   if (isAuthenticated) {
     return null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -95,6 +95,22 @@ export const authApi = {
     return response.data;
   },
 
+  async autoLogin(): Promise<AuthResponse> {
+    try {
+      const response = await apiClient.post('/api/auth/auto-login');
+      setAuthenticatedState(true);
+      return response.data;
+    } catch (error) {
+      clearAuthenticatedState();
+      throw error;
+    }
+  },
+
+  async getPersonalModeInfo(): Promise<any> {
+    const response = await apiClient.get('/api/auth/personal-mode-info');
+    return response.data;
+  },
+
   async refreshToken(): Promise<void> {
     try {
       await apiClient.post('/api/auth/refresh');

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -17,12 +17,15 @@ interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
   error: string | null;
+  personalModeInfo: any;
 
   // アクション
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
   initialize: () => void;
   clearError: () => void;
+  autoLogin: () => Promise<void>;
+  getPersonalModeInfo: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
@@ -30,6 +33,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isAuthenticated: false,
   isLoading: false,
   error: null,
+  personalModeInfo: null,
 
   login: async (username: string, password: string) => {
     set({ isLoading: true, error: null });
@@ -71,22 +75,74 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     });
   },
 
-  initialize: () => {
+  initialize: async () => {
     if (typeof window !== 'undefined') {
-      const isAuth = getAuthenticatedState();
-      if (isAuth) {
-        // 実際の実装では、認証状態の有効性を確認する
-        set({
-          user: {
-            id: '1',
-            username: 'admin',
-            email: 'admin@example.com',
-          },
-          isAuthenticated: true,
-          isLoading: false,
-          error: null,
-        });
+      try {
+        // 個人モード情報を取得
+        await get().getPersonalModeInfo();
+        
+        const personalModeInfo = get().personalModeInfo;
+        
+        // 個人モードで自動ログインが有効な場合
+        if (personalModeInfo?.personal_mode && personalModeInfo?.auto_login) {
+          await get().autoLogin();
+        } else {
+          // 通常の認証状態確認
+          const isAuth = getAuthenticatedState();
+          if (isAuth) {
+            set({
+              user: {
+                id: '1',
+                username: 'admin',
+                email: 'admin@example.com',
+              },
+              isAuthenticated: true,
+              isLoading: false,
+              error: null,
+            });
+          }
+        }
+      } catch (error) {
+        console.log('Initialize auth failed (possibly normal):', error);
       }
+    }
+  },
+
+  autoLogin: async () => {
+    set({ isLoading: true, error: null });
+    
+    try {
+      const response = await authApi.autoLogin();
+      
+      set({
+        user: response.user,
+        isAuthenticated: true,
+        isLoading: false,
+        error: null,
+      });
+    } catch (error: any) {
+      const errorMessage = 
+        typeof error === 'string'
+          ? error
+          : error?.response?.data?.detail || error?.message || '自動ログインに失敗しました';
+      
+      set({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: errorMessage,
+      });
+      throw error;
+    }
+  },
+
+  getPersonalModeInfo: async () => {
+    try {
+      const personalModeInfo = await authApi.getPersonalModeInfo();
+      set({ personalModeInfo });
+    } catch (error) {
+      console.log('Failed to get personal mode info:', error);
+      set({ personalModeInfo: { personal_mode: false, auto_login: false } });
     }
   },
 

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -80,9 +80,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       try {
         // 個人モード情報を取得
         await get().getPersonalModeInfo();
-        
+
         const personalModeInfo = get().personalModeInfo;
-        
+
         // 個人モードで自動ログインが有効な場合
         if (personalModeInfo?.personal_mode && personalModeInfo?.auto_login) {
           await get().autoLogin();
@@ -110,10 +110,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   autoLogin: async () => {
     set({ isLoading: true, error: null });
-    
+
     try {
       const response = await authApi.autoLogin();
-      
+
       set({
         user: response.user,
         isAuthenticated: true,
@@ -121,11 +121,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         error: null,
       });
     } catch (error: any) {
-      const errorMessage = 
+      const errorMessage =
         typeof error === 'string'
           ? error
           : error?.response?.data?.detail || error?.message || '自動ログインに失敗しました';
-      
+
       set({
         user: null,
         isAuthenticated: false,

--- a/packages/backend/src/crypto_bot/core/config.py
+++ b/packages/backend/src/crypto_bot/core/config.py
@@ -59,6 +59,12 @@ class Settings(BaseSettings):
     NTFY_TOPIC: str = "crypto-bot-alerts"
     NTFY_SERVER: str = "https://ntfy.sh"
 
+    # Personal Mode Settings
+    PERSONAL_MODE: bool = False
+    PERSONAL_MODE_AUTO_LOGIN: bool = False
+    PERSONAL_MODE_DEFAULT_USER: str = "demo"
+    PERSONAL_MODE_SKIP_LIVE_TRADING_AUTH: bool = False
+
     class Config:
         env_file = ".env"
         case_sensitive = True


### PR DESCRIPTION
## 📋 概要
個人利用向けの認証簡素化機能（Phase A）を実装しました。ユーザーがログイン画面をスキップして直接ダッシュボードにアクセスできるようになります。

## ✨ 実装内容

### 🔧 環境変数設定
- `PERSONAL_MODE`: 個人モード有効/無効の制御
- `PERSONAL_MODE_AUTO_LOGIN`: 自動ログイン機能の制御
- `PERSONAL_MODE_DEFAULT_USER`: デフォルトログインユーザー（demo）
- `PERSONAL_MODE_SKIP_LIVE_TRADING_AUTH`: ライブ取引認証スキップ制御

### 🚀 バックエンドAPI追加
- **POST `/api/auth/auto-login`**: 個人モード用自動ログイン
- **GET `/api/auth/personal-mode-info`**: 個人モード設定情報取得
- **GET `/api/auth/health`**: 個人モード状態を含むヘルスチェック

### 💻 フロントエンド機能
- 自動認証フローの実装
- 個人モード時のログインページスキップ
- 認証状態の自動管理

## 📁 変更ファイル
- `.env.example`: 個人モード環境変数テンプレート追加
- `api/auth_simple.py`: 自動ログイン機能とモード情報API実装
- `frontend/src/store/auth.ts`: 自動認証ロジック実装
- `frontend/src/lib/api.ts`: 個人モードAPI関数追加
- `frontend/src/app/login/page.tsx`: 個人モード対応
- `packages/backend/src/crypto_bot/core/config.py`: 設定クラス拡張

## 🔒 セキュリティ考慮
- JWT認証システムは維持
- API保護機能は継続
- 個人モードは環境変数で完全制御
- ライブ取引等の重要機能は追加認証可能

## 🧪 Vercel本番環境でのテスト方法

### 1. 環境変数設定（Vercel Dashboard）
```
PERSONAL_MODE=true
PERSONAL_MODE_AUTO_LOGIN=true
NEXT_PUBLIC_PERSONAL_MODE=true
NEXT_PUBLIC_PERSONAL_MODE_AUTO_LOGIN=true
```

### 2. 動作確認手順
1. `/api/auth/personal-mode-info` で設定確認
2. トップページアクセスで自動ログイン動作確認
3. ダッシュボード直接遷移の確認

## ✅ チェックリスト
- [x] 環境変数テンプレート更新
- [x] バックエンドAPI実装
- [x] フロントエンド自動認証実装
- [x] 既存認証システムとの互換性確認
- [x] 適切なブランチでの開発
- [x] コミットメッセージ規約準拠

## 🎯 次のステップ
Phase B「シンプルBot操作UI」への移行準備完了

🤖 Generated with [Claude Code](https://claude.ai/code)